### PR TITLE
Allow the specification of group ownership on wp_cli_command. #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Execute WP-CLI with the desired command and arguments.
 * `stdin` - Free text to the standard input (see `wp core config --extra-php`)
 * `cwd` - WordPress installation path.
 * `user` - Execute WP-CLI with under the desired user privileges.
+* `group` - Execute WP-CLI under the desired group privileges.
 
 ### Examples:
 

--- a/providers/command.rb
+++ b/providers/command.rb
@@ -9,6 +9,7 @@ action :execute do
     command "#{node['wp-cli']['bin']} #{command}#{args_str}#{stdin}"
     cwd new_resource.cwd
     user new_resource.user
+    group new_resource.group
     sensitive new_resource.sensitive
   end
 end

--- a/resources/command.rb
+++ b/resources/command.rb
@@ -6,6 +6,7 @@ attribute :command, :kind_of => String, :name_attribute => true
 attribute :cwd, :kind_of => String, :default => nil
 attribute :stdin, :kind_of => String, :default => nil
 attribute :user, :kind_of => String, :default => nil
+attribute :group, :kind_of => String, :default => nil
 attribute :sensitive, :kind_of => [TrueClass, FalseClass], :default => false
 
 def initialize(*args)


### PR DESCRIPTION
Fixes issue #8.